### PR TITLE
Change how types are being done

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,9 +1,9 @@
-type PROJECT_GQL_CONFIG = {
-  manager: Boolean
-  provider: Boolean
-  resident: Boolean
-  web: Boolean
-  mobile: Boolean
+interface PROJECT_GQL_CONFIG = {
+  manager: boolean
+  provider: boolean
+  resident: boolean
+  web: boolean
+  mobile: boolean
 }
 
 export class ConditionalField {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-interface PROJECT_GQL_CONFIG = {
+interface PROJECT_GQL_CONFIG {
   manager: boolean
   provider: boolean
   resident: boolean


### PR DESCRIPTION
:warning: **This PR is NOT ready to be merged!** :warning:

Line 1: `interface` is preferred over `type`

Line 2-6: Don't use `String`, `Number`, and `Boolean` (and others), use `string`, `number`, and `boolean`

**Questions & Stylistic Suggestions**

Line 14: 
Argument 1 `base`: use `string[]` instead of `Array<string>`
Argument ...2 `...variables`: What is the function's actual interface like? What I can see, type `(params: type) => returnVal` is used for functions. Is this type correct: `(data: PROJECT_GQL_CONFIG) => any`?